### PR TITLE
Fix 10 bugs across audio engine, storage, and editor components

### DIFF
--- a/src/audio/AudioEngine.ts
+++ b/src/audio/AudioEngine.ts
@@ -124,23 +124,19 @@ export class AudioEngine {
         console.log('[AudioEngine] Tone.jsのインポートが完了しました');
       }
       
-      console.log('[AudioEngine] 現在のTone.jsコンテキスト状態:', this.Tone.getContext().state);
-      
+      const toneContext = this.Tone.getContext();
+      if (!toneContext) {
+        throw new Error('Tone.jsのAudioContextを取得できませんでした。');
+      }
+      console.log('[AudioEngine] 現在のTone.jsコンテキスト状態:', toneContext.state);
+
       // Tone.jsを使用してAudioContextを開始
-      // これにより、ユーザーインタラクション時にAudioContextが適切に作成・開始される
-      if (this.Tone.getContext().state === 'suspended') {
-        console.log('[AudioEngine] Tone.jsのAudioContextを開始します...');
+      if (toneContext.state !== 'running') {
+        console.log('[AudioEngine] Tone.jsのAudioContextを開始します（状態:', toneContext.state, '）');
         await this.Tone.start();
         console.log('[AudioEngine] Tone.jsのAudioContextが開始されました');
-      } else if (this.Tone.getContext().state === 'closed') {
-        console.log('[AudioEngine] AudioContextが閉じられています。Tone.jsで再作成します...');
-        await this.Tone.start();
-        console.log('[AudioEngine] 新しいAudioContextが作成・開始されました');
-      } else if (this.Tone.getContext().state === 'running') {
-        console.log('[AudioEngine] AudioContextは既に実行中です');
       } else {
-        console.log('[AudioEngine] 不明なAudioContext状態、Tone.start()を実行します:', this.Tone.getContext().state);
-        await this.Tone.start();
+        console.log('[AudioEngine] AudioContextは既に実行中です');
       }
       
       // コンテキストの参照を更新

--- a/src/audio/SoundSource.ts
+++ b/src/audio/SoundSource.ts
@@ -269,12 +269,10 @@ export class SoundSource {
         console.log('[SoundSource] Tone.jsのインポートが完了しました');
       }
 
-      // AudioContextが存在しない場合は、楽器設定のみ保存して実際の作成は遅延
+      // AudioContextが存在しない、またはclosedの場合は作成できないためエラー
       const context = this.Tone.getContext();
       if (!context || context.state === 'closed') {
-        console.log(`[SoundSource] AudioContextが未作成のため、楽器 ${type} の作成を遅延します`);
-        // 楽器が「読み込み済み」として扱われるが、実際のシンセサイザーは後で作成
-        return;
+        throw new Error(`AudioContextが利用できないため楽器 ${type} を作成できません。AudioContextを開始してから再試行してください。`);
       }
 
       const config = this._getSynthConfig(type);
@@ -516,14 +514,21 @@ export class SoundSource {
       }
     }
 
-    // 読み込み中の場合はキャンセル（実際のキャンセルは困難なので、完了後に削除）
+    // 読み込み中の場合はPromiseを取り出してから削除し、完了後にsynthを破棄
     if (this.loadingPromises.has(type)) {
-      this.loadingPromises.get(type)?.then(() => {
-        this.unloadInstrument(type);
-      }).catch(() => {
-        // 読み込みエラーの場合は何もしない
-      });
+      const pendingPromise = this.loadingPromises.get(type)!;
       this.loadingPromises.delete(type);
+      pendingPromise.then(() => {
+        // 読み込み完了後に作成されたsynthを破棄
+        const synth = this.synthMap.get(type);
+        if (synth) {
+          try { synth.dispose(); } catch {}
+          this.synthMap.delete(type);
+          console.log(`[SoundSource] 遅延作成された楽器 ${type} を解放しました`);
+        }
+      }).catch(() => {
+        // 読み込みエラーの場合はsynthが作成されないため何もしない
+      });
     }
   }
 

--- a/src/components/ScorePage.tsx
+++ b/src/components/ScorePage.tsx
@@ -20,14 +20,16 @@ import type { MeasureData } from '../types/storage';
 
 type PageSpec = { systems: number };
 
+const BEATS_PER_MEASURE = 4; // 4/4拍子固定
+
 // 譜面の総再生時間を計算するヘルパー関数
 function calculateScoreDuration(scoreData: MeasureData[], bpm: number): number {
   let totalDuration = 0;
-  
+
   for (const measure of scoreData) {
     if (!measure || !measure.events || measure.events.length === 0) {
-      // 空の小節は全休符として扱う（4拍）
-      totalDuration += (60 / bpm) * 4;
+      // 空の小節は全休符として扱う
+      totalDuration += (60 / bpm) * BEATS_PER_MEASURE;
     } else {
       // 各音符の時間を合計
       for (const event of measure.events) {
@@ -284,9 +286,13 @@ export default function ScorePage() {
 
   const [columns, setColumns] = useState(window.innerWidth < 1200 ? 1 : 2);
   useEffect(() => {
-    const onResize = () => setColumns(window.innerWidth < 1200 ? 1 : 2);
+    let timer: ReturnType<typeof setTimeout>;
+    const onResize = () => {
+      clearTimeout(timer);
+      timer = setTimeout(() => setColumns(window.innerWidth < 1200 ? 1 : 2), 150);
+    };
     window.addEventListener('resize', onResize);
-    return () => window.removeEventListener('resize', onResize);
+    return () => { window.removeEventListener('resize', onResize); clearTimeout(timer); };
   }, []);
 
   const { spreadRef, scale } = useAutoPageScale(columns, 20);

--- a/src/components/StaffCanvas.tsx
+++ b/src/components/StaffCanvas.tsx
@@ -206,7 +206,7 @@ function snapLineBySpacing(stave: Stave, y: number): number {
     
     if (diff < minDiff) {
       minDiff = diff;
-      bestLine = Number(line.toFixed(1)); // 浮動小数点誤差を回避
+      bestLine = Math.round(line * 2) / 2; // 0.5刻みで正確に丸める
     }
   }
   
@@ -274,7 +274,11 @@ export default function StaffCanvas({
     return Array.from({ length: totalMeasures }, () => ({ events: [] }));
   });
   const [selected, setSelected] = useState<{ measure: number; index: number } | null>(null);
-  
+  const selectedRef = useRef(selected);
+  const disabledRef = useRef(disabled);
+  useEffect(() => { selectedRef.current = selected; }, [selected]);
+  useEffect(() => { disabledRef.current = disabled; }, [disabled]);
+
   // NotePlayerインスタンスの管理
   const notePlayerRef = useRef<NotePlayer | null>(null);
   const soundSourceRef = useRef<SoundSource | null>(null);
@@ -400,7 +404,8 @@ export default function StaffCanvas({
   /* ===== キー操作（削除/上下移動/解除） ===== */
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
-      if (!selected || disabled) return; // disabledチェックを追加
+      const selected = selectedRef.current;
+      if (!selected || disabledRef.current) return;
       const { measure, index } = selected;
       const inRange = (arr: any[], i: number) => i >= 0 && i < arr.length;
 
@@ -456,7 +461,7 @@ export default function StaffCanvas({
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  }, [selected, disabled]); // disabledを依存配列に追加
+  }, []); // refを使うため依存不要、マウント時に1度だけ登録
 
   /* ======================== 描画 ======================== */
   useEffect(() => {
@@ -671,11 +676,12 @@ export default function StaffCanvas({
             const dL = Math.abs(localX - measLeft); if (dL < minDist) { minDist = dL; insertAt = 0; }
             const dR = Math.abs(localX - measRight); if (dR < minDist) { minDist = dR; insertAt = vfNotes.length; }
 
+            const fallbackNoteWidth = Math.max(20, wDraw / (vfNotes.length + 1));
             for (let j = 0; j < vfNotes.length; j++) {
               const n: any = vfNotes[j];
-              const leftX = n.getAbsoluteX ? n.getAbsoluteX() : (measLeft + j * 20);
+              const leftX = n.getAbsoluteX ? n.getAbsoluteX() : (measLeft + (j + 1) * (wDraw / (vfNotes.length + 1)));
               const bb = n.getBoundingBox?.();
-              const width = bb ? bb.getW() : 20;
+              const width = bb ? bb.getW() : fallbackNoteWidth;
               const rightX = leftX + width;
 
               if (localX >= leftX && localX <= rightX) {

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -281,15 +281,30 @@ export function loadScoreData(): StorageResult<SavedScoreData | null> {
         if (metadata.dataChecksum) {
           const currentChecksum = generateChecksum(rawData);
           if (currentChecksum !== metadata.dataChecksum) {
-            // Checksum mismatch - data may be corrupted
-            // Try backup if available
-            const backupData = localStorage.getItem(STORAGE_KEYS.BACKUP);
-            if (backupData && backupData !== rawData) {
-              // Recursively try to load from backup
-              // Clear primary and retry
-              localStorage.removeItem(STORAGE_KEYS.PRIMARY);
-              return loadScoreData();
+            // Checksum mismatch on primary - try backup directly (no recursion)
+            const backupRaw = localStorage.getItem(STORAGE_KEYS.BACKUP);
+            if (backupRaw && backupRaw !== rawData) {
+              try {
+                const backupParsed = JSON.parse(backupRaw);
+                if (
+                  validateSavedScoreData(backupParsed) &&
+                  generateChecksum(backupRaw) === metadata.dataChecksum
+                ) {
+                  // Backup is valid - use it
+                  return { success: true, data: backupParsed };
+                }
+              } catch {
+                // Backup also corrupted, fall through to error
+              }
             }
+            return {
+              success: false,
+              error: {
+                type: StorageErrorType.CORRUPTED_DATA,
+                message: 'Stored data checksum verification failed. Data may be corrupted.',
+                recoverable: true
+              }
+            };
           }
         }
       }


### PR DESCRIPTION
-storage.ts**: `loadScoreData()` の再帰処理をインラインのバックアップ確認に置き換え。これにより、二重のチェックサム不一致が発生した際に処理が止まってしまう（ハングする）問題を解消。
-SoundSource.ts**: AudioContextが利用できない場合、何もせず戻る（誤って「読み込み完了」状態になる）のではなく、エラーをスローするように変更。また、`unloadInstrument` 内で、マップから削除する前にPromiseの参照を保持することでリソースリークを修正。
-AudioEngine.ts**: `getContext()` にnullガードを追加し、重複していた if-else-if 分岐を簡素化。
-StaffCanvas.tsx**: 浮動小数点の丸め処理を修正 (`toFixed(1)` → `Math.round*2/2`)。`getBoundingBox()` がnullを返した際のフォールバックを、比率に基づいた幅に改善。keydownリスナーに `ref` を使用し、選択が変更されるたびではなく一度だけ登録されるように修正。
-ScorePage.tsx**: 空の小節の拍数のために `BEATS_PER_MEASURE` 定数を抽出。リサイズハンドラーに150msのデバウンス（遅延実行）を追加し、過剰な再レンダリングを防止。

- storage.ts: Replace recursive loadScoreData() with inline backup check to eliminate potential hang on dual-checksum-mismatch scenario
- SoundSource.ts: Throw error when AudioContext unavailable instead of silently returning (false "loaded" state); fix resource leak in unloadInstrument by holding Promise reference before deleting from map
- AudioEngine.ts: Add null guard for getContext() and simplify duplicated if-else-if branches
- StaffCanvas.tsx: Fix floating-point snap (toFixed(1) → Math.round*2/2); improve getBoundingBox() null fallback to proportional width; use refs for keydown listener so it registers only once instead of on every selection change
- ScorePage.tsx: Extract BEATS_PER_MEASURE constant for empty-measure duration; add 150ms debounce to resize handler to prevent excessive re-renders